### PR TITLE
Change Members update & delete fcns to void

### DIFF
--- a/src/domain/members/controller/members.controller.spec.ts
+++ b/src/domain/members/controller/members.controller.spec.ts
@@ -23,6 +23,10 @@ describe('members controller', () => {
     await app.init();
   });
 
+  beforeEach(async () => {
+    jest.resetAllMocks();
+  });
+
   it('should create a new member', async () => {
     jest.spyOn(membersService, 'createMember').mockImplementation();
 
@@ -203,26 +207,15 @@ describe('members controller', () => {
     expect(res.body.data).toEqual([]);
   });
 
-  it('should return the updated member', async () => {
-    const data = {
-      id: 1,
-      score: 0,
-      numAttend: 0,
-      name: 'testName1',
-      username: 'test1',
-      program: Program.COMPUTER_SCIENCE,
-      role: Role.MEMBER,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+  it('update request should succeed with a status code 200', async () => {
     const userId = 1;
     const key = configService.getTokenData().accessTokenSecret;
     const token = createUserToken(userId, key, { expiresIn: '1h' });
 
-    jest.spyOn(membersService, 'editMember').mockResolvedValueOnce(data);
+    jest.spyOn(membersService, 'editMember').mockImplementation();
 
     const res = await request(app.getHttpServer())
-      .put(`/v1/members/${data.id}`)
+      .put(`/v1/members/${userId}`)
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
@@ -234,7 +227,8 @@ describe('members controller', () => {
     const userId = 1;
     const key = configService.getTokenData().accessTokenSecret;
     const token = createUserToken(userId, key, { expiresIn: '1h' });
-    const memberId = 100;
+    const memberId = 1000;
+
     const res = await request(app.getHttpServer())
       .put(`/v1/members/${memberId}`)
       .set('Authorization', `Bearer ${token}`)
@@ -246,26 +240,16 @@ describe('members controller', () => {
     assertStatusCode(res, 400);
   });
 
-  it('should return the deleted member', async () => {
-    const data = {
-      id: 1,
-      score: 0,
-      numAttend: 0,
-      name: 'testName1',
-      username: 'test1',
-      program: Program.COMPUTER_SCIENCE,
-      role: Role.MEMBER,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
+  it('delete request should succeed with ca status code 200', async () => {
     const userId = 1;
     const key = configService.getTokenData().accessTokenSecret;
     const token = createUserToken(userId, key, { expiresIn: '1h' });
+    const memberId = 1;
 
-    jest.spyOn(membersService, 'removeMember').mockResolvedValueOnce(data);
+    jest.spyOn(membersService, 'removeMember').mockImplementation();
 
     const res = await request(app.getHttpServer())
-      .delete(`/v1/members/${data.id}`)
+      .delete(`/v1/members/${memberId}`)
       .set('Authorization', `Bearer ${token}`);
 
     assertStatusCode(res, 200);
@@ -277,6 +261,7 @@ describe('members controller', () => {
     const key = configService.getTokenData().accessTokenSecret;
     const token = createUserToken(userId, key, { expiresIn: '1h' });
     const memberId = 100;
+
     const res = await request(app.getHttpServer())
       .delete(`/v1/members/${memberId}`)
       .set('Authorization', `Bearer ${token}`);

--- a/src/domain/members/controller/members.controller.ts
+++ b/src/domain/members/controller/members.controller.ts
@@ -89,9 +89,9 @@ export class MembersController {
   async updateMember(
     @TypedParam('id') id: number,
     @TypedBody() memberData: MemberUpdateRequestDTO,
-  ): Promise<BaseResponseDto<MembersResponseDTO>> {
-    const res = await editMember(id, memberData);
-    return new BaseResponseDto(res);
+  ): Promise<BaseResponseDto<object>> {
+    await editMember(id, memberData);
+    return new BaseResponseDto({ state: 'success' });
   }
 
   /**
@@ -104,8 +104,8 @@ export class MembersController {
   @HttpCode(200)
   async deleteMember(
     @TypedParam('id') id: number,
-  ): Promise<BaseResponseDto<MembersResponseDTO>> {
-    const res = await removeMember(id);
-    return new BaseResponseDto(res);
+  ): Promise<BaseResponseDto<object>> {
+    await removeMember(id);
+    return new BaseResponseDto({ state: 'success' });
   }
 }

--- a/src/domain/members/repository/members.repository.spec.ts
+++ b/src/domain/members/repository/members.repository.spec.ts
@@ -102,19 +102,10 @@ describe('members repository', () => {
     const memberId = 1;
 
     await saveMember({ ...dto });
-
-    const res = await updateMember(memberId, { ...expected });
+    await updateMember(memberId, { ...expected });
+    const res = await getMemberById(memberId);
 
     expect(res).not.toBeNull();
-
-    expect(res.id).toEqual(memberId);
-
-    expect(res.score).toEqual(10);
-    expect(res.numAttend).toEqual(1);
-    expect(res.name).toEqual('testName2');
-    expect(res.username).toEqual('test2');
-    expect(res.program).toEqual('Mathematics');
-    expect(res.role).toEqual('Admin');
   });
 
   it('should not be able to return a member after deletion', async () => {
@@ -130,7 +121,6 @@ describe('members repository', () => {
 
     await saveMember({ ...dto });
     await deleteMember(memberId);
-
     const res = await getMemberById(memberId);
 
     expect(res).toBeNull();

--- a/src/domain/members/repository/members.repository.ts
+++ b/src/domain/members/repository/members.repository.ts
@@ -35,7 +35,7 @@ export async function updateMember(
     role?: Role;
   },
 ) {
-  return await prismaClient.members.update({
+  await prismaClient.members.update({
     where: {
       id: id,
     },
@@ -47,7 +47,7 @@ export async function updateMember(
 }
 
 export async function deleteMember(id: number) {
-  return await prismaClient.members.delete({
+  await prismaClient.members.delete({
     where: {
       id: id,
     },

--- a/src/domain/members/service/members.service.spec.ts
+++ b/src/domain/members/service/members.service.spec.ts
@@ -149,9 +149,10 @@ describe('members service', () => {
     };
 
     await createMember({ ...dto });
-
     const memberId = 1;
-    const res = await editMember(memberId, { ...expected });
+
+    await editMember(memberId, { ...expected });
+    const res = await getMember(memberId);
 
     expect(res).not.toBeNull();
     expect(res.id).toEqual(memberId);

--- a/src/domain/members/service/members.service.ts
+++ b/src/domain/members/service/members.service.ts
@@ -64,7 +64,7 @@ export async function editMember(
     );
   }
 
-  return await updateMember(id, param);
+  await updateMember(id, param);
 }
 
 export async function removeMember(id: number) {
@@ -77,7 +77,7 @@ export async function removeMember(id: number) {
     );
   }
 
-  return await deleteMember(id);
+  await deleteMember(id);
 }
 
 export async function getLeaderboard() {


### PR DESCRIPTION
# 설명
- made update and delete fcns to void

# ISSUE
- update and delete fcns are unnecessarily returning an object. 

# 테스트
- members.controller.spec.ts
- members.service.spec.ts
- members.repository.spec.ts