### PR TITLE
Chore/kakao login

### DIFF
--- a/src/domain/account/repository/account.repository.ts
+++ b/src/domain/account/repository/account.repository.ts
@@ -34,11 +34,16 @@ export async function saveAccounts(
 }
 
 export async function getIdentification(identification: string) {
-  return prismaClient.accounts.findFirst({
+  const res = prismaClient.accounts.findFirst({
     where: {
       identification: identification,
     },
   });
+
+  return {
+    ...res,
+    role: Role,
+  };
 }
 
 export function findAccessToken(accessToken: string) {

--- a/src/domain/account/repository/account.repository.ts
+++ b/src/domain/account/repository/account.repository.ts
@@ -34,15 +34,17 @@ export async function saveAccounts(
 }
 
 export async function getIdentification(identification: string) {
-  const res = prismaClient.accounts.findFirst({
+  const res = await prismaClient.accounts.findFirst({
     where: {
       identification: identification,
     },
   });
 
+  if (!res) return null;
+
   return {
     ...res,
-    role: Role,
+    role: res.role as Role,
   };
 }
 

--- a/src/domain/account/repository/account.repository.ts
+++ b/src/domain/account/repository/account.repository.ts
@@ -34,13 +34,24 @@ export async function saveAccounts(
 }
 
 export async function getIdentification(identification: string) {
-  const res = await prismaClient.accounts.findFirst({
+  let res = await prismaClient.accounts.findFirst({
     where: {
       identification: identification,
     },
   });
 
   if (!res) return null;
+
+  if (Role[res.role] === undefined) {
+    res = await prismaClient.accounts.update({
+      where: {
+        id: res.id,
+      },
+      data: {
+        role: Role.UNKNOWN,
+      },
+    });
+  }
 
   return {
     ...res,

--- a/src/domain/account/service/account.service.ts
+++ b/src/domain/account/service/account.service.ts
@@ -25,6 +25,7 @@ export async function getAccount(identification: string) {
       'no data',
     );
   }
+
   return data;
 }
 
@@ -44,7 +45,14 @@ export function findAccessToken(accessToken: string) {
 
 export async function createToken(param: CreateTokenRequest) {
   const identification = await getKakaoUserData(param.code);
-  const entity = await getAccount(identification);
+  const entity = await getAccount(String(identification)).catch(async () => {
+    const newAccountParam = {
+      identification: String(identification),
+      role: Role.UNKNOWN,
+    };
+    await createAccount(newAccountParam);
+    return getAccount(String(identification));
+  });
 
   const tokens = makeTokens({ userId: entity.id });
   await saveToken({

--- a/src/domain/members/repository/members.repository.ts
+++ b/src/domain/members/repository/members.repository.ts
@@ -12,15 +12,29 @@ export async function saveMember(param: {
 }
 
 export async function getMembers() {
-  return await prismaClient.members.findMany();
+  const res = await prismaClient.members.findMany();
+
+  return res?.map((member) => {
+    return {
+      ...member,
+      program: member.program as Program,
+    };
+  });
 }
 
 export async function getMemberById(id: number) {
-  return await prismaClient.members.findFirst({
+  const res = await prismaClient.members.findFirst({
     where: {
       id: id,
     },
   });
+
+  if (!res) return null;
+
+  return {
+    ...res,
+    program: res.program as Program,
+  };
 }
 
 export async function updateMember(

--- a/src/third_party/kakao/kakao.ts
+++ b/src/third_party/kakao/kakao.ts
@@ -10,7 +10,6 @@ export async function getKakaoUserData(code: string) {
         Authorization: `bearer ${accessToken}`,
       },
     });
-    console.log(res?.data?.id);
 
     return res?.data?.id;
   } catch (error) {


### PR DESCRIPTION
# 설명
- converted integer value into String when calling getAccount() and necessary fcn(s). 
- implemented a try-catch to create a new account if the account did not exist upon logging in (temporarily made role to be UNKNOWN for all accounts when created like this).

# ISSUE
- identification retrieved from kakao was integer, but our getAccount() fcn expected it to be String. 
- simply throws an error if an account does not exist, preventing from further work. 

# 테스트
N/A
