### PR TITLE
feat: add verificaiton attribute to the account table

### DIFF
--- a/prisma/migrations/20250321191409_add_verification_account_table/migration.sql
+++ b/prisma/migrations/20250321191409_add_verification_account_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "accounts" ADD COLUMN     "verification" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20250328205341_remove_verification_account_table/migration.sql
+++ b/prisma/migrations/20250328205341_remove_verification_account_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `verification` on the `accounts` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "accounts" DROP COLUMN "verification";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,10 +10,9 @@ datasource db {
 model Accounts {
   id             Int      @id @default(autoincrement())
   identification String   @map("identification") @db.VarChar(256)
-  role           String   @map("role") @db.VarChar(10)
-  verification   Boolean  @default(false) @map("verification")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
+  role           String   @map("role") @db.VarChar(10)
 
   @@map("accounts")
 }
@@ -35,9 +34,9 @@ model Members {
   id        Int      @id @default(autoincrement())
   score     Int      @default(0) @map("score")
   name      String   @map("name") @db.VarChar(25)
-  accountId String   @default("0") @map("accountId") @db.VarChar(25)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+  accountId String   @default("0") @map("accountId") @db.VarChar(25)
 
   @@map("members")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ model Accounts {
   id             Int      @id @default(autoincrement())
   identification String   @map("identification") @db.VarChar(256)
   role           String   @map("role") @db.VarChar(10)
+  verification   Boolean  @default(false) @map("verification")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
 

--- a/src/common/exception/exception.filter.ts
+++ b/src/common/exception/exception.filter.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import {
+  UnauthorizedException,
   BaseException,
   CallerWrongUsageException,
 } from '@common/exception/internal.exception';
@@ -46,6 +47,21 @@ export class HttpExceptionFilter implements ExceptionFilter {
       if (!(exception instanceof CallerWrongUsageException)) {
         Sentry.captureException(exception, { extra: detailResponse });
       }
+
+      response.status(status).json(detailResponse);
+      return;
+    }
+
+    if (exception instanceof UnauthorizedException) {
+      const status = exception.getStatus();
+
+      const detailResponse = {
+        statusCode: status,
+        timestamp: new Date().toISOString(),
+        path: request.url,
+        originMessage: exception.message,
+        input: request.body,
+      };
 
       response.status(status).json(detailResponse);
       return;

--- a/src/common/exception/internal.exception.ts
+++ b/src/common/exception/internal.exception.ts
@@ -121,7 +121,7 @@ export class EmptyContentException extends HttpException {
 }
 
 export class UnauthorizedException extends HttpException {
-  constructor(message: string) {
-    super(HttpException.createBody({ message }), HttpStatus.UNAUTHORIZED);
+  constructor() {
+    super(HttpException.createBody({}), HttpStatus.UNAUTHORIZED);
   }
 }

--- a/src/common/exception/internal.exception.ts
+++ b/src/common/exception/internal.exception.ts
@@ -119,3 +119,9 @@ export class EmptyContentException extends HttpException {
     super(HttpException.createBody({ message }), HttpStatus.NO_CONTENT);
   }
 }
+
+export class UnauthorizedException extends HttpException {
+  constructor(message: string) {
+    super(HttpException.createBody({ message }), HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/src/domain/account/repository/account.repository.ts
+++ b/src/domain/account/repository/account.repository.ts
@@ -42,7 +42,7 @@ export async function getIdentification(identification: string) {
 
   if (!res) return null;
 
-  if (Role[res.role] === undefined) {
+  if (res.role != Role.MEMBER && res.role != Role.UNKNOWN) {
     res = await prismaClient.accounts.update({
       where: {
         id: res.id,

--- a/src/domain/account/service/account.service.ts
+++ b/src/domain/account/service/account.service.ts
@@ -58,9 +58,7 @@ export async function createToken(param: CreateTokenRequest) {
 
   if (!entity.verification) {
     // account not verified yet, return status code 403
-    throw new UnauthorizedException(
-      'Account successfully registered, waiting for access approval.',
-    );
+    throw new UnauthorizedException();
   }
 
   const tokens = makeTokens({ userId: entity.id });

--- a/src/domain/account/service/account.service.ts
+++ b/src/domain/account/service/account.service.ts
@@ -16,7 +16,7 @@ import { pipe } from 'fp-ts/lib/function';
 import { saveToken } from '@domain/account/repository/token.repository';
 import { getKakaoUserData } from '@root/src/third_party/kakao/kakao';
 import { CreateTokenRequest } from '../dto/account.dto';
-import { Role } from '../account.enum';
+import { Role } from '@domain/account/account.enum';
 
 export type AccountEntity = Awaited<ReturnType<typeof getAccount>>;
 export async function getAccount(identification: string) {
@@ -56,8 +56,8 @@ export async function createToken(param: CreateTokenRequest) {
     return getAccount(String(identification));
   });
 
-  if (!entity.verification) {
-    // account not verified yet, return status code 403
+  if (entity.role === Role.UNKNOWN) {
+    // account not verified yet, return status code 401
     throw new UnauthorizedException();
   }
 


### PR DESCRIPTION
Used to verify accounts upon sign up

# Description
- add verification attribute to the accounts table. 
- upon sign up, the verification is set to false by default. 
- will have to wait until the verification has been changed to true before sending session token. 

# Issue
#75 

# Testing
N/A
