### PR TITLE
feat: implement executives domain repository

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -70,6 +70,7 @@ type tableNames =
   | 'members'
   | 'events'
   | 'resources'
+  | 'executives'
 
 async function truncateTables(prisma: PrismaClient, tableNames: tableNames[]) {
   const url = process.env.DATABASE_URL ?? '';

--- a/prisma/migrations/20260817182848_add_executives_table/migration.sql
+++ b/prisma/migrations/20260817182848_add_executives_table/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "executives" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(25) NOT NULL,
+    "position" VARCHAR(50) NOT NULL,
+    "image_url" VARCHAR(512),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "executives_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,3 +73,14 @@ model Resource {
 
   @@map("resources")
 }
+
+model Executive {
+  id         Int      @id @default(autoincrement())
+  name       String   @db.VarChar(25)
+  position   String   @db.VarChar(50)
+  image_url  String?  @db.VarChar(512)
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
+
+  @@map("executives")
+}

--- a/src/domain/executives/repository/executives.repository.spec.ts
+++ b/src/domain/executives/repository/executives.repository.spec.ts
@@ -22,10 +22,12 @@ describe('executives repository', () => {
     const res = await getExecutives();
 
     expect(res).toHaveLength(2);
-    expect(res[0].name).toEqual('test-name-1');
-    expect(res[0].position).toEqual('test-position-1');
-    expect(res[0].imageUrl).toEqual('test-image-url');
-    expect(res[1].name).toEqual('test-name-2');
-    expect(res[1].imageUrl).toEqual('');
+
+    const first = res.find((it) => it.name === 'test-name-1');
+    expect(first?.position).toEqual('test-position-1');
+    expect(first?.imageUrl).toEqual('test-image-url');
+
+    const second = res.find((it) => it.name === 'test-name-2');
+    expect(second?.imageUrl).toEqual('');
   });
 });

--- a/src/domain/executives/repository/executives.repository.spec.ts
+++ b/src/domain/executives/repository/executives.repository.spec.ts
@@ -1,0 +1,31 @@
+import { truncateTables } from '@root/jest.setup';
+import { loadFixture } from '@root/test/utils/db-test-helper';
+import prismaClient from '@common/database/prisma';
+import { getExecutives } from '@domain/executives/repository/executives.repository';
+
+describe('executives repository', () => {
+  afterEach(async () => {
+    await truncateTables(prismaClient, ['executives']);
+  });
+
+  it('should return an empty array when there are no executives', async () => {
+    const res = await getExecutives();
+    expect(res).toEqual([]);
+  });
+
+  it('should return all executives', async () => {
+    await loadFixture(
+      prismaClient,
+      'test/fixtures/executives/executives.setup.sql',
+    );
+
+    const res = await getExecutives();
+
+    expect(res).toHaveLength(2);
+    expect(res[0].name).toEqual('test-name-1');
+    expect(res[0].position).toEqual('test-position-1');
+    expect(res[0].imageUrl).toEqual('test-image-url');
+    expect(res[1].name).toEqual('test-name-2');
+    expect(res[1].imageUrl).toEqual('');
+  });
+});

--- a/src/domain/executives/repository/executives.repository.spec.ts
+++ b/src/domain/executives/repository/executives.repository.spec.ts
@@ -21,13 +21,16 @@ describe('executives repository', () => {
 
     const res = await getExecutives();
 
+    expect(res).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'test-name-1',
+          position: 'test-position-1',
+          imageUrl: 'test-image-url',
+        }),
+        expect.objectContaining({ name: 'test-name-2', imageUrl: '' }),
+      ]),
+    );
     expect(res).toHaveLength(2);
-
-    const first = res.find((it) => it.name === 'test-name-1');
-    expect(first?.position).toEqual('test-position-1');
-    expect(first?.imageUrl).toEqual('test-image-url');
-
-    const second = res.find((it) => it.name === 'test-name-2');
-    expect(second?.imageUrl).toEqual('');
   });
 });

--- a/src/domain/executives/repository/executives.repository.ts
+++ b/src/domain/executives/repository/executives.repository.ts
@@ -10,24 +10,10 @@ export interface ExecutiveRecord {
   updatedAt: Date;
 }
 
-export interface IExecutivesRepository {
-  getExecutives(): Promise<ExecutiveRecord[]>;
-}
-
-export class ExecutivesRepository implements IExecutivesRepository {
-  async getExecutives(): Promise<ExecutiveRecord[]> {
-    const records = await prismaClient.executive.findMany({
-      orderBy: { id: 'asc' },
-    });
-
-    return records.map(toExecutiveRecord);
-  }
-}
-
-const executivesRepository = new ExecutivesRepository();
-
 export async function getExecutives(): Promise<ExecutiveRecord[]> {
-  return executivesRepository.getExecutives();
+  const records = await prismaClient.executive.findMany();
+
+  return records.map(toExecutiveRecord);
 }
 
 function toExecutiveRecord(record: ExecutiveEntity): ExecutiveRecord {

--- a/src/domain/executives/repository/executives.repository.ts
+++ b/src/domain/executives/repository/executives.repository.ts
@@ -1,0 +1,42 @@
+import { Executive as ExecutiveEntity } from '@prisma/client';
+import prismaClient from '@common/database/prisma';
+
+export interface ExecutiveRecord {
+  id: number;
+  name: string;
+  position: string;
+  imageUrl: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IExecutivesRepository {
+  getExecutives(): Promise<ExecutiveRecord[]>;
+}
+
+export class ExecutivesRepository implements IExecutivesRepository {
+  async getExecutives(): Promise<ExecutiveRecord[]> {
+    const records = await prismaClient.executive.findMany({
+      orderBy: { id: 'asc' },
+    });
+
+    return records.map(toExecutiveRecord);
+  }
+}
+
+const executivesRepository = new ExecutivesRepository();
+
+export async function getExecutives(): Promise<ExecutiveRecord[]> {
+  return executivesRepository.getExecutives();
+}
+
+function toExecutiveRecord(record: ExecutiveEntity): ExecutiveRecord {
+  return {
+    id: record.id,
+    name: record.name,
+    position: record.position,
+    imageUrl: record.image_url ?? '',
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  };
+}

--- a/test/fixtures/executives/executives.setup.sql
+++ b/test/fixtures/executives/executives.setup.sql
@@ -1,0 +1,5 @@
+INSERT INTO "executives" (name, position, image_url, updated_at)
+VALUES ('test-name-1', 'test-position-1', 'test-image-url', NOW());
+
+INSERT INTO "executives" (name, position, updated_at)
+VALUES ('test-name-2', 'test-position-2', NOW());


### PR DESCRIPTION
# Description
Implemented the domain repository layer for executive members.

- Added `Executive` model to `prisma/schema.prisma` (name, position, image_url)
- Implemented `ExecutivesRepository` with the `IExecutivesRepository` interface
- Followed the existing patterns from the `events` domain
- Added `executives` to the `tableNames` type in `jest.setup.ts`

Note: There was no Executive-related model in the schema, so I added one based on the acceptance criteria in #82. Please let me know if the field structure or the ordering (currently ascending by id) needs adjustment.

# Issue
Closes #86

# Testing
All tests pass with `npm run test:seq`.

- Returns an empty array when no executives exist
- Returns all executives with correct field mapping
- Converts null `image_url` to an empty string

Test fixture: `test/fixtures/executives/executives.setup.sql`