### PR TITLE
feat: implement executives domain service

### DIFF
--- a/src/domain/executives/service/executives.service.spec.ts
+++ b/src/domain/executives/service/executives.service.spec.ts
@@ -1,0 +1,47 @@
+import * as executivesRepository from '@domain/executives/repository/executives.repository';
+import { ExecutiveRecord } from '@domain/executives/repository/executives.repository';
+import { getExecutives } from '@domain/executives/service/executives.service';
+
+describe('executives service', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return an empty array when the repository has no executives', async () => {
+    jest.spyOn(executivesRepository, 'getExecutives').mockResolvedValueOnce([]);
+
+    const res = await getExecutives();
+
+    expect(res).toEqual([]);
+  });
+
+  it('should return whatever the repository returns', async () => {
+    const executives: ExecutiveRecord[] = [
+      {
+        id: 1,
+        name: 'test-name',
+        position: 'test-position',
+        imageUrl: '',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    jest
+      .spyOn(executivesRepository, 'getExecutives')
+      .mockResolvedValueOnce(executives);
+
+    const res = await getExecutives();
+
+    expect(res).toEqual(executives);
+  });
+
+  it('should delegate to the repository exactly once', async () => {
+    const spy = jest
+      .spyOn(executivesRepository, 'getExecutives')
+      .mockResolvedValueOnce([]);
+
+    await getExecutives();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/executives/service/executives.service.ts
+++ b/src/domain/executives/service/executives.service.ts
@@ -1,0 +1,8 @@
+import {
+  getExecutives as getExecutiveRecords,
+  ExecutiveRecord,
+} from '@domain/executives/repository/executives.repository';
+
+export async function getExecutives(): Promise<ExecutiveRecord[]> {
+  return getExecutiveRecords();
+}


### PR DESCRIPTION
# Description
Implemented the domain service layer for executive members.

- Added `getExecutives` in `executives.service.ts`, delegating to the repository
- Followed the existing pattern from the `events` domain
- Kept it as a plain function without a class or interface, per the feedback on #97

There are no business rules for executives at the moment, so the service simply passes the repository result through.

# Issue
Closes #85

# Testing
All tests pass with `npm run test:seq`.

- Returns an empty array when the repository has none
- Returns whatever the repository returns
- Delegates to the repository exactly once

The repository is mocked with `jest.spyOn`, so the service tests don't touch the database.