### PR TITLE
84 executives controller

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,12 +3,14 @@ import { ConfigModule } from '@nestjs/config';
 import { LoggingModule } from '@src/common/logging/logging.module';
 import { ConfigurationModule } from '@domain/configuration/configuration.module';
 import { EventsModule } from '@domain/events/events.module';
+import { ExecutivesModule } from '@domain/executives/executives.module';
 import { validate } from '@src/env.validation';
 
 @Module({
   imports: [
     ConfigurationModule,
     EventsModule,
+    ExecutivesModule,
     ConfigModule.forRoot({
       cache: true,
       isGlobal: true,

--- a/src/domain/executives/controller/executives.controller.spec.ts
+++ b/src/domain/executives/controller/executives.controller.spec.ts
@@ -1,0 +1,67 @@
+import { INestApplication } from '@nestjs/common';
+import { TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import { appModuleFixture, assertStatusCode } from '@root/jest.setup';
+import * as executivesService from '@domain/executives/service/executives.service';
+import { ExecutivesController } from '@domain/executives/controller/executives.controller';
+import { ExecutiveRecord } from '@domain/executives/repository/executives.repository';
+
+describe('executives controller', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = (await appModuleFixture(
+      [ExecutivesController],
+      [],
+    )) as TestingModule;
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+  });
+
+  describe('/v1/executives', () => {
+    it('should return an empty array when there are no executives', async () => {
+      jest.spyOn(executivesService, 'getExecutives').mockResolvedValueOnce([]);
+
+      const res = await request(app.getHttpServer()).get('/v1/executives');
+
+      assertStatusCode(res, 200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('should return the executives from the service', async () => {
+      const executives: ExecutiveRecord[] = [
+        {
+          id: 1,
+          name: 'test-name',
+          position: 'test-position',
+          imageUrl: '',
+          createdAt: new Date('2500-01-01'),
+          updatedAt: new Date('2500-01-01'),
+        },
+      ];
+      jest
+        .spyOn(executivesService, 'getExecutives')
+        .mockResolvedValueOnce(executives);
+
+      const res = await request(app.getHttpServer()).get('/v1/executives');
+
+      assertStatusCode(res, 200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.data[0]).toHaveProperty('name', 'test-name');
+    });
+
+    it('should call the service exactly once', async () => {
+      const spy = jest
+        .spyOn(executivesService, 'getExecutives')
+        .mockResolvedValueOnce([]);
+
+      await request(app.getHttpServer()).get('/v1/executives');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/domain/executives/controller/executives.controller.ts
+++ b/src/domain/executives/controller/executives.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, HttpCode } from '@nestjs/common';
+import { TypedRoute } from '@nestia/core';
+import { getExecutives } from '@domain/executives/service/executives.service';
+import { BaseResponseDto } from '@common/dto/base.dto';
+import { ExecutiveResponseDto } from '@domain/executives/dto/executives.dto';
+
+@Controller('v1/executives')
+export class ExecutivesController {
+  /**
+   * List every AKCSE executive member.
+   *
+   * @tag executives
+   * @summary get all executive members
+   */
+  @TypedRoute.Get('/')
+  @HttpCode(200)
+  async getExecutives(): Promise<BaseResponseDto<ExecutiveResponseDto[]>> {
+    const executives = await getExecutives();
+    return new BaseResponseDto(executives);
+  }
+}

--- a/src/domain/executives/dto/executives.dto.ts
+++ b/src/domain/executives/dto/executives.dto.ts
@@ -1,0 +1,36 @@
+import { tags } from 'typia';
+
+export interface ExecutiveResponseDto {
+  /**
+   * executive id
+   * @type number
+   */
+  id: number & tags.Example<1>;
+  /**
+   * executive name
+   * @type string
+   */
+  name: string & tags.Example<'Donggeon Yang'>;
+  /**
+   * executive position
+   * @type string
+   */
+  position: string & tags.Example<'President'>;
+  /**
+   * executive image url, empty string if not set
+   * @type string
+   */
+  imageUrl: string & tags.Example<'https://cdn.akcse.org/team/president.png'>;
+  /**
+   * executive created at
+   * example: "2025-08-01T09:12:34Z"
+   * @type string
+   */
+  createdAt: Date;
+  /**
+   * executive updated at
+   * example: "2025-08-03T14:02:11Z"
+   * @type string
+   */
+  updatedAt: Date;
+}

--- a/src/domain/executives/executives.module.ts
+++ b/src/domain/executives/executives.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ExecutivesController } from '@domain/executives/controller/executives.controller';
+
+@Module({
+  controllers: [ExecutivesController],
+})
+export class ExecutivesModule {}

--- a/src/domain/executives/service/executives.service.spec.ts
+++ b/src/domain/executives/service/executives.service.spec.ts
@@ -1,0 +1,47 @@
+import * as executivesRepository from '@domain/executives/repository/executives.repository';
+import { ExecutiveRecord } from '@domain/executives/repository/executives.repository';
+import { getExecutives } from '@domain/executives/service/executives.service';
+
+describe('executives service', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return an empty array when the repository has no executives', async () => {
+    jest.spyOn(executivesRepository, 'getExecutives').mockResolvedValueOnce([]);
+
+    const res = await getExecutives();
+
+    expect(res).toEqual([]);
+  });
+
+  it('should return whatever the repository returns', async () => {
+    const executives: ExecutiveRecord[] = [
+      {
+        id: 1,
+        name: 'test-name',
+        position: 'test-position',
+        imageUrl: '',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    jest
+      .spyOn(executivesRepository, 'getExecutives')
+      .mockResolvedValueOnce(executives);
+
+    const res = await getExecutives();
+
+    expect(res).toEqual(executives);
+  });
+
+  it('should delegate to the repository exactly once', async () => {
+    const spy = jest
+      .spyOn(executivesRepository, 'getExecutives')
+      .mockResolvedValueOnce([]);
+
+    await getExecutives();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domain/executives/service/executives.service.ts
+++ b/src/domain/executives/service/executives.service.ts
@@ -1,0 +1,8 @@
+import {
+  getExecutives as getExecutiveRecords,
+  ExecutiveRecord,
+} from '@domain/executives/repository/executives.repository';
+
+export async function getExecutives(): Promise<ExecutiveRecord[]> {
+  return getExecutiveRecords();
+}


### PR DESCRIPTION
# Description
Implemented the `GET /v1/executives` endpoint and registered the module.

- Added `ExecutiveResponseDto` with typia tags for schema documentation
- Added `ExecutivesController` with `TypedRoute.Get`, returning `BaseResponseDto`
- Added `ExecutivesModule` and registered it in `app.module.ts`
- Followed the existing pattern from the `events` domain

Note: The issue mentions `@ApiTags` / `@ApiOperation`, but this codebase uses nestia's `TypedRoute` with JSDoc `@tag` / `@summary` annotations for schema generation, so I followed the events controller pattern instead. Happy to switch if you'd prefer the decorator approach.

I included the module registration here since the endpoint isn't reachable without it, but I can split it into a separate PR if you'd rather keep them apart.

# Issue
Closes #84
Closes #87

# Testing
All tests pass with `npm run test:seq`.

- Returns an empty array when the service has none
- Returns the executives from the service
- Calls the service exactly once

Verified locally that `GET /v1/executives` is mapped and returns `{"data":[]}`.
